### PR TITLE
Implement AI settings and OpenAI features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import BookReaderView from "./pages/BookReaderView"; // Import BookReaderView
+import Settings from "./pages/Settings";
 
 const queryClient = new QueryClient();
 
@@ -18,6 +19,8 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/book/:bookId" element={<BookReaderView />} />
+          <Route path="/settings" element={<Settings />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -108,7 +108,7 @@ export function BookCard(props: BookCardProps) { // Changed to accept props dire
                     console.log("onPlayAudioBook prop not provided for ID:", id);
                   }
                 } else {
-                  navigate(`/read/${id}`);
+                  navigate(`/book/${id}`);
                 }
               }}
             >

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 
 import { useState, useEffect } from "react";
-import { Moon, Sun, Search, Bell } from "lucide-react";
+import { Moon, Sun, Search, Bell, Settings as SettingsIcon } from "lucide-react";
+import { Link } from 'react-router-dom';
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Input } from "@/components/ui/input";
@@ -61,6 +62,12 @@ export function Header() {
             <Badge className="absolute -top-1 -right-1 h-5 w-5 rounded-full p-0 flex items-center justify-center text-xs bg-secondary">
               3
             </Badge>
+          </Button>
+
+          <Button asChild variant="ghost" size="icon">
+            <Link to="/settings">
+              <SettingsIcon className="h-5 w-5" />
+            </Link>
           </Button>
 
           <Avatar className="h-8 w-8 cursor-pointer hover:ring-2 hover:ring-primary transition-all">

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,0 +1,55 @@
+export async function callOpenAI(apiKey: string, messages: any[]): Promise<string> {
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages,
+    }),
+  });
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content?.trim() || '';
+}
+
+export async function summarizeLibrary(apiKey: string): Promise<string> {
+  const stored = localStorage.getItem('myBooks');
+  const books = stored ? JSON.parse(stored) : [];
+  const summaryData = books.map((b: any) => ({
+    title: b.title,
+    progress: b.progress,
+    currentPage: b.currentPage,
+    totalPages: b.totalPages,
+    readTimeMinutes: b.readTimeMinutes,
+  }));
+  const messages = [
+    {
+      role: 'system',
+      content: 'You help readers recall what they have read.',
+    },
+    {
+      role: 'user',
+      content: `Here is my library as JSON: ${JSON.stringify(summaryData)}. Summarize my progress so I can quickly catch up.`,
+    },
+  ];
+  return callOpenAI(apiKey, messages);
+}
+
+export async function recommendBook(apiKey: string): Promise<string> {
+  const stored = localStorage.getItem('myBooks');
+  const books = stored ? JSON.parse(stored) : [];
+  const titles = books.map((b: any) => b.title).join(', ');
+  const messages = [
+    {
+      role: 'system',
+      content: 'You recommend new books based on the user\'s library.',
+    },
+    {
+      role: 'user',
+      content: `My current books are: ${titles}. Suggest a new book I might enjoy and explain why.`,
+    },
+  ];
+  return callOpenAI(apiKey, messages);
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { summarizeLibrary, recommendBook } from '@/lib/openai';
+
+const SettingsPage: React.FC = () => {
+  const [apiKey, setApiKey] = useState('');
+  const [response, setResponse] = useState('');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('openaiApiKey');
+    if (stored) setApiKey(stored);
+  }, []);
+
+  const saveKey = () => {
+    localStorage.setItem('openaiApiKey', apiKey);
+  };
+
+  const handleSummarize = async () => {
+    try {
+      const summary = await summarizeLibrary(apiKey);
+      setResponse(summary);
+    } catch (err) {
+      setResponse('Failed to get summary');
+      console.error(err);
+    }
+  };
+
+  const handleRecommend = async () => {
+    try {
+      const rec = await recommendBook(apiKey);
+      setResponse(rec);
+    } catch (err) {
+      setResponse('Failed to get recommendation');
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-4 space-y-4">
+      <h2 className="text-2xl font-bold">Settings</h2>
+      <div className="space-y-2">
+        <label className="text-sm font-medium">OpenAI API Key</label>
+        <Input
+          type="password"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder="sk-..."
+        />
+        <Button onClick={saveKey}>Save Key</Button>
+      </div>
+      <div className="flex gap-4 pt-4">
+        <Button onClick={handleSummarize}>Summarize Library</Button>
+        <Button variant="outline" onClick={handleRecommend}>
+          Recommend Book
+        </Button>
+      </div>
+      {response && (
+        <pre className="mt-4 whitespace-pre-wrap p-4 border rounded-md bg-muted/20">
+          {response}
+        </pre>
+      )}
+    </div>
+  );
+};
+
+export default SettingsPage;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,4 +9,8 @@ export interface Book {
   isAudiobook: boolean;
   content: string; // For text of e-books
   audioSrc?: string; // For audio file URL
+  currentPage?: number;
+  totalPages?: number;
+  readTimeMinutes?: number;
+  chapter?: number;
 }


### PR DESCRIPTION
## Summary
- add a settings page for storing an OpenAI API key
- integrate summary and recommendation helpers using OpenAI
- expose the new page via routing and a link in the header
- track optional book stats for better prompts
- update navigation paths for reading a book

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684665ad96e48328b4929be276524d05