### PR TITLE
Fix epubjs import resolution

### DIFF
--- a/src/components/ImportBookButton.tsx
+++ b/src/components/ImportBookButton.tsx
@@ -1,7 +1,8 @@
 import React, { useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import type { Book } from '@/types';
-import ePub from 'epubjs';
+// Use explicit path to the ESM build of epubjs so Vite can resolve it
+import ePub from 'epubjs/dist/epub.js';
 import { getDocument, GlobalWorkerOptions } from 'pdfjs-dist/build/pdf.mjs'; // Import from modern build
 
 // Configure PDF.js worker


### PR DESCRIPTION
## Summary
- import epubjs from explicit ESM build to avoid resolution errors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68466d71dc30832884d18bd541bec3e4