### PR TITLE
Implement reading timer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,15 +14,18 @@ const queryClient = new QueryClient();
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
+      <StatsProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/read/:bookId" element={<BookReaderView />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </StatsProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/hooks/useReadingTimer.tsx
+++ b/src/hooks/useReadingTimer.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Hook that tracks active reading time.
+ * Calls `onMinuteRead` every minute while the user is active.
+ * @param isActive Start tracking when true
+ * @param onMinuteRead Callback executed for each active minute
+ * @param idleTimeout Duration in ms after which the user is considered idle
+ */
+export function useReadingTimer(
+  isActive: boolean,
+  onMinuteRead: () => void,
+  idleTimeout = 60_000,
+) {
+  const lastActivityRef = useRef(Date.now());
+  const secondsRef = useRef(0);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (!isActive) return;
+
+    const handleActivity = () => {
+      lastActivityRef.current = Date.now();
+    };
+
+    const events: (keyof DocumentEventMap)[] = [
+      'mousemove',
+      'mousedown',
+      'keydown',
+      'scroll',
+      'touchstart',
+    ];
+
+    events.forEach(e => window.addEventListener(e, handleActivity));
+
+    intervalRef.current = setInterval(() => {
+      if (Date.now() - lastActivityRef.current < idleTimeout) {
+        secondsRef.current += 1;
+        if (secondsRef.current >= 60) {
+          onMinuteRead();
+          secondsRef.current -= 60;
+        }
+      }
+    }, 1000);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+      events.forEach(e => window.removeEventListener(e, handleActivity));
+    };
+  }, [isActive, idleTimeout, onMinuteRead]);
+}
+
+export default useReadingTimer;

--- a/src/pages/BookReaderView.tsx
+++ b/src/pages/BookReaderView.tsx
@@ -4,6 +4,7 @@ import type { Book } from '@/types';
 import { useTTS } from '@/hooks/useTTS';
 import { Button } from '@/components/ui/button';
 import { useStats } from '@/contexts/StatsContext'; // Import useStats
+import useReadingTimer from '@/hooks/useReadingTimer';
 
 // Removed BookReaderViewProps interface and onActivity from props
 
@@ -17,6 +18,12 @@ const BookReaderView: React.FC = () => { // Removed onActivity from props
   const { recordUserActivity, incrementMinutesRead, markBookAsCompleted } = useStats(); // Use stats context
   const contentRef = useRef<HTMLDivElement>(null);
   const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Track active reading time and update stats
+  useReadingTimer(true, () => {
+    incrementMinutesRead(1);
+    recordUserActivity();
+  });
 
   // Function to save scroll progress
   const saveScrollProgress = () => {


### PR DESCRIPTION
## Summary
- add global stats provider and reading route
- track active reading time with `useReadingTimer`
- increment reading minutes and streak while viewing a book

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68539ce63da48328a15bccbe88a4167e