### PR TITLE
Add Vitest setup and tests for components

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -85,6 +86,10 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.33.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.1.4",
+    "vitest": "^1.5.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/components/__tests__/AudioPlayer.test.tsx
+++ b/src/components/__tests__/AudioPlayer.test.tsx
@@ -1,0 +1,19 @@
+import { render, fireEvent } from '@testing-library/react';
+import { AudioPlayer } from '../AudioPlayer';
+import React from 'react';
+
+describe('AudioPlayer', () => {
+  it('plays and pauses audio', async () => {
+    const playSpy = vi.spyOn(window.HTMLMediaElement.prototype, 'play').mockImplementation(() => Promise.resolve());
+    const pauseSpy = vi.spyOn(window.HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+
+    const { container } = render(<AudioPlayer audioSrc="test.mp3" />);
+    const playButton = container.querySelector('svg.lucide-play')!.closest('button') as HTMLButtonElement;
+    await fireEvent.click(playButton);
+    expect(playSpy).toHaveBeenCalled();
+    expect(container.querySelector('svg.lucide-pause')).toBeTruthy();
+
+    await fireEvent.click(playButton);
+    expect(pauseSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/ImportBookButton.test.tsx
+++ b/src/components/__tests__/ImportBookButton.test.tsx
@@ -1,0 +1,25 @@
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { ImportBookButton } from '../ImportBookButton';
+import React from 'react';
+
+vi.mock('epubjs', () => ({ default: vi.fn() }));
+vi.mock('pdfjs-dist/build/pdf.mjs', () => ({
+  getDocument: vi.fn(),
+  GlobalWorkerOptions: {},
+}));
+vi.mock('jsmediatags', () => ({ default: { read: vi.fn() } }));
+
+describe('ImportBookButton', () => {
+  it('imports plain text files', async () => {
+    const onBookImported = vi.fn();
+    const { container } = render(<ImportBookButton onBookImported={onBookImported} />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['hello world'], 'test.txt', { type: 'text/plain' });
+    await fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() => expect(onBookImported).toHaveBeenCalled());
+    const book = onBookImported.mock.calls[0][0];
+    expect(book.title).toBe('test');
+    expect(book.content).toBe('hello world');
+    expect(book.isAudiobook).toBe(false);
+  });
+});

--- a/src/contexts/__tests__/StatsContext.test.tsx
+++ b/src/contexts/__tests__/StatsContext.test.tsx
@@ -1,0 +1,18 @@
+import { renderHook, act } from '@testing-library/react';
+import { StatsProvider, useStats } from '../StatsContext';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <StatsProvider>{children}</StatsProvider>
+);
+
+describe('StatsContext', () => {
+  it('increments imported books and completed ids', () => {
+    const { result } = renderHook(() => useStats(), { wrapper });
+    act(() => {
+      result.current.incrementTotalBooksImported();
+      result.current.markBookAsCompleted('1');
+    });
+    expect(result.current.userStats.totalBooksImported).toBe(1);
+    expect(result.current.userStats.completedBookIds).toContain('1');
+  });
+});

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "**/*.test.ts", "**/*.test.tsx", "vitest.setup.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react-swc';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- integrate Vitest with jsdom environment
- add basic tests for ImportBookButton, AudioPlayer, and StatsContext
- expose `npm test` script

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68539ccbb34c83289c073144d38d6252