### PR TITLE
Update README with supported book types

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Supported Book Types
+
+You can import books in the following formats:
+
+- `.txt`
+- `.epub`
+- `.pdf`
+- `.mp3`
+- `.m4a`
+- `.m4b`
+
+Books with Digital Rights Management (DRM) or other encryption are not supported.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/56561f21-2ba6-49d6-bcad-661ce65fa793) and click on Share -> Publish.


### PR DESCRIPTION
## Summary
- document import support for `.txt`, `.epub`, `.pdf`, `.mp3`, `.m4a`, and `.m4b`
- clarify that DRM-protected formats aren't supported

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68539cc5e72c8328bdc349500c203ea0