### PR TITLE
Use SVG placeholder for PWA icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,13 @@ Yes it is!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Installing the app
+
+After building or visiting the deployed site you can install it as a Progressive Web App.
+
+- **Mobile (Android)**: Open the site in Chrome and choose **Add to Home screen** from the menu.
+- **Mobile (iOS)**: Open the site in Safari, tap the share icon, then select **Add to Home Screen**.
+- **Desktop**: In Chrome or Edge, click the install button in the address bar or open the browser menu and choose **Install app**.
+
+Once installed the app launches in its own window and can work offline after the first visit.

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <link rel="manifest" href="/manifest.json" />
   </head>
 
   <body>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Read Spark Delight",
+  "short_name": "ReadSpark",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#111827",
+  "description": "Offline capable reader for ebooks and audiobooks.",
+  "icons": [
+    {
+      "src": "/placeholder.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/placeholder.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,51 @@
+const APP_CACHE = 'app-cache-v1';
+const BOOK_CACHE = 'book-cache-v1';
+const APP_ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/placeholder.svg',
+];
+
+self.addEventListener('install', event => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(APP_CACHE).then(cache => cache.addAll(APP_ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(k => k !== APP_CACHE && k !== BOOK_CACHE).map(k => caches.delete(k))
+    ))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (url.origin === location.origin && url.pathname.startsWith('/books/')) {
+    event.respondWith(
+      caches.open(BOOK_CACHE).then(cache =>
+        cache.match(request).then(resp =>
+          resp || fetch(request).then(r => { cache.put(request, r.clone()); return r; })
+        )
+      )
+    );
+    return;
+  }
+
+  if (request.method === 'GET' && url.origin === location.origin) {
+    event.respondWith(
+      caches.match(request).then(resp =>
+        resp || fetch(request).then(r => {
+          const clone = r.clone();
+          caches.open(APP_CACHE).then(cache => cache.put(request, clone));
+          return r;
+        })
+      )
+    );
+  }
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,3 +3,9 @@ import App from './App.tsx'
 import './index.css'
 
 createRoot(document.getElementById("root")!).render(<App />);
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/service-worker.js');
+  });
+}


### PR DESCRIPTION
## Summary
- replace binary icon files with an SVG placeholder
- update manifest and service worker references

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68539cc2b4f08328ba988629e01f6910