### PR TITLE
Persist theme selection

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,6 +11,10 @@ export function Header() {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored === "light" || stored === "dark") {
+      setTheme(stored);
+    }
     setMounted(true);
   }, []);
 
@@ -21,6 +25,7 @@ export function Header() {
     } else {
       root.classList.remove("dark");
     }
+    localStorage.setItem("theme", theme);
   }, [theme]);
 
   const toggleTheme = () => {


### PR DESCRIPTION
## Summary
- store chosen theme in `localStorage`
- read saved theme on mount

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68539cb3e5d08328b9ca3e6c62470242