### PR TITLE
Add audio duration handling

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -27,6 +27,7 @@ interface AudioPlayerProps {
   onFinish?: () => void;
   onTimeUpdate?: (currentTime: number, duration: number) => void;
   initialProgressPercent?: number;
+  onDurationAvailable?: (duration: number) => void;
 }
 
 export function AudioPlayer({
@@ -36,6 +37,7 @@ export function AudioPlayer({
   onFinish,
   onTimeUpdate,
   initialProgressPercent,
+  onDurationAvailable,
 }: AudioPlayerProps) {
   const audioRef = useRef<HTMLAudioElement>(null);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -73,6 +75,9 @@ export function AudioPlayer({
         audio.currentTime = initialTime;
         setCurrentTime(initialTime); // Also update React state
       }
+      if (onDurationAvailable) {
+        onDurationAvailable(audio.duration);
+      }
     };
     const handleTimeUpdate = () => {
       setCurrentTime(audio.currentTime);
@@ -101,7 +106,7 @@ export function AudioPlayer({
       audio.removeEventListener("volumechange", handleVolumeChangeEv);
       audio.removeEventListener("ratechange", handleRateChange);
     };
-}, [onFinish, audioSrc]); // Added audioSrc to re-run if src changes and new listeners might be needed on a new object
+}, [onFinish, onDurationAvailable, audioSrc]); // Added audioSrc and callback deps
 
 
   const formatTime = (seconds: number) => {

--- a/src/components/ImportBookButton.tsx
+++ b/src/components/ImportBookButton.tsx
@@ -8,6 +8,29 @@ import jsmediatags from 'jsmediatags'; // Import jsmediatags
 // Configure PDF.js worker
 GlobalWorkerOptions.workerSrc = '/pdf.worker.mjs';
 
+// Utility to get duration of an audio file
+const getAudioDuration = (url: string): Promise<number> => {
+  return new Promise((resolve) => {
+    const audio = document.createElement('audio');
+    const cleanup = () => {
+      audio.removeEventListener('loadedmetadata', onLoaded);
+      audio.removeEventListener('error', onError);
+    };
+    const onLoaded = () => {
+      cleanup();
+      resolve(isNaN(audio.duration) ? 0 : audio.duration);
+    };
+    const onError = () => {
+      cleanup();
+      resolve(0);
+    };
+    audio.addEventListener('loadedmetadata', onLoaded);
+    audio.addEventListener('error', onError);
+    audio.preload = 'metadata';
+    audio.src = url;
+  });
+};
+
 
 interface ImportBookButtonProps {
   onBookImported: (book: Book) => void;
@@ -171,7 +194,7 @@ export function ImportBookButton({ onBookImported }: ImportBookButtonProps) {
                file.name.toLowerCase().endsWith(".m4a") ||
                file.name.toLowerCase().endsWith(".m4b")) {
 
-      const createBookWithFallbacks = (fileObj: File, audioUrl: string, errorInfo?: any) => {
+      const createBookWithFallbacks = (fileObj: File, audioUrl: string, duration: number, errorInfo?: any) => {
         if (errorInfo) console.error("Error reading audio tags, using fallbacks:", errorInfo);
         const fallbackTitle = fileObj.name.replace(/\.[^/.]+$/, "");
         onBookImported({
@@ -185,11 +208,13 @@ export function ImportBookButton({ onBookImported }: ImportBookButtonProps) {
           isAudiobook: true,
           content: errorInfo ? `Failed to read tags: ${errorInfo.type} ${errorInfo.info}` : "Audiobook",
           audioSrc: audioUrl,
+          audioSrcDuration: duration,
           contentType: 'text',
         });
       };
 
       const audioUrl = URL.createObjectURL(file);
+      const duration = await getAudioDuration(audioUrl);
 
       jsmediatags.read(file, {
         onSuccess: (tagData) => {
@@ -218,12 +243,13 @@ export function ImportBookButton({ onBookImported }: ImportBookButtonProps) {
             isAudiobook: true,
             content: tags.comment?.text || tags.lyrics?.lyrics || "", // Use comment or lyrics
             audioSrc: audioUrl,
+            audioSrcDuration: duration,
             contentType: 'text',
           };
           onBookImported(newBook);
         },
         onError: (error) => {
-          createBookWithFallbacks(file, audioUrl, error);
+          createBookWithFallbacks(file, audioUrl, duration, error);
         }
       });
     } else {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -132,6 +132,14 @@ const Index = () => {
     setCurrentAudio(book);
   };
 
+  const handleAudioDurationAvailable = (duration: number) => {
+    if (!currentAudio) return;
+    setBooks(prevBooks => prevBooks.map(b => b.id === currentAudio.id ? { ...b, audioSrcDuration: duration } : b));
+    setCurrentAudio(prev => prev ? { ...prev, audioSrcDuration: duration } : prev);
+    const initialReportedTime = currentAudio.progress ? (currentAudio.progress / 100) * duration : 0;
+    lastReportedAudioTimeRef.current = { bookId: currentAudio.id, time: initialReportedTime };
+  };
+
   const handleAudioTimeUpdate = (newCurrentTime: number, duration: number) => {
     if (currentAudio && duration > 0) {
       const progress = (newCurrentTime / duration) * 100;
@@ -174,7 +182,7 @@ const Index = () => {
     if (currentAudio) {
       // When a new audio book is selected, set its initial reported time based on its progress.
       // This helps in calculating delta correctly from where it resumed.
-      const initialReportedTime = currentAudio.progress && currentAudio.audioSrcDuration // Assuming audioSrcDuration is available
+      const initialReportedTime = currentAudio.progress && currentAudio.audioSrcDuration
         ? (currentAudio.progress / 100) * currentAudio.audioSrcDuration
         : 0;
       lastReportedAudioTimeRef.current = { bookId: currentAudio.id, time: initialReportedTime };
@@ -326,6 +334,7 @@ const Index = () => {
         bookTitle={currentAudio?.title || "No book selected"}
         chapter={currentAudio ? currentAudio.author : "Unknown author"}
         onTimeUpdate={handleAudioTimeUpdate}
+        onDurationAvailable={handleAudioDurationAvailable}
         initialProgressPercent={currentAudio?.progress}
       />
     </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export interface Book {
   isAudiobook: boolean;
   content: string; // For text of e-books
   audioSrc?: string; // For audio file URL
+  audioSrcDuration?: number; // Duration of audio in seconds
   contentType?: 'text' | 'html';
 }
 


### PR DESCRIPTION
## Summary
- track audio duration for audiobooks
- expose loaded duration from the player
- save duration when importing audio books
- use duration in Index page and remove TODO comment

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68539caf3cd48328b39559b9bed5493c