### PR TITLE
Add achievement utilities and dynamic stats

### DIFF
--- a/src/components/ReaderStats.tsx
+++ b/src/components/ReaderStats.tsx
@@ -1,34 +1,18 @@
 import { Headphones, Award, BookOpen, Clock, Calendar } from "lucide-react";
 // Removed ProgressBar import as goals are removed
 import { AchievementBadge } from "./AchievementBadge";
+import { useStats } from "@/contexts/StatsContext";
+import { computeAchievements } from "@/lib/achievements";
 
-interface ReaderStatsProps {
-  // dailyGoal and weeklyGoal removed
-  booksCompleted: number;
-  minutesRead: number;
-  minutesListened: number; // Added
-  currentStreak: number;
-  longestStreak: number;
-  achievements: {
-    id: string;
-    title: string;
-    description: string;
-    type: "gold" | "silver" | "bronze" | "locked";
-    progress?: number;
-    maxProgress?: number;
-    isNew?: boolean;
-  }[];
-}
+export function ReaderStats() {
+  const { userStats } = useStats();
+  const achievements = computeAchievements(userStats);
 
-export function ReaderStats({
-  // dailyGoal and weeklyGoal removed
-  booksCompleted,
-  minutesRead,
-  minutesListened, // Added
-  currentStreak,
-  longestStreak,
-  achievements
-}: ReaderStatsProps) {
+  const booksCompleted = userStats.completedBookIds.length;
+  const minutesRead = Math.round(userStats.totalMinutesRead);
+  const minutesListened = Math.round(userStats.totalMinutesListened);
+  const currentStreak = userStats.currentStreak;
+  const longestStreak = userStats.longestStreak;
   return (
     <div className="space-y-6">
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4"> {/* Adjusted grid for 5 items */}

--- a/src/lib/__tests__/achievements.test.ts
+++ b/src/lib/__tests__/achievements.test.ts
@@ -1,0 +1,40 @@
+import { computeAchievements } from '../achievements';
+import type { UserStats } from '@/types';
+
+describe('computeAchievements', () => {
+  it('locks achievements when progress is low', () => {
+    const stats: UserStats = {
+      totalBooksImported: 0,
+      completedBookIds: [],
+      totalMinutesRead: 0,
+      totalMinutesListened: 0,
+      currentStreak: 0,
+      longestStreak: 0,
+      lastReadingDate: null,
+    };
+
+    const achievements = computeAchievements(stats);
+    achievements.forEach(a => {
+      expect(a.type).toBe('locked');
+    });
+  });
+
+  it('unlocks achievements when requirements met', () => {
+    const stats: UserStats = {
+      totalBooksImported: 10,
+      completedBookIds: ['1','2','3','4','5'],
+      totalMinutesRead: 300,
+      totalMinutesListened: 0,
+      currentStreak: 10,
+      longestStreak: 10,
+      lastReadingDate: '2024-01-01',
+    };
+
+    const achievements = computeAchievements(stats);
+    const ids = Object.fromEntries(achievements.map(a => [a.id, a.type]));
+    expect(ids['streak_10']).toBe('gold');
+    expect(ids['minutes_300']).toBe('silver');
+    expect(ids['books_5']).toBe('bronze');
+    expect(ids['import_10']).toBe('bronze');
+  });
+});

--- a/src/lib/achievements.ts
+++ b/src/lib/achievements.ts
@@ -1,0 +1,61 @@
+export interface AchievementDefinition {
+  id: string;
+  title: string;
+  description: string;
+  type: 'gold' | 'silver' | 'bronze';
+  getProgress: (stats: import('../types').UserStats) => { progress: number; max: number };
+}
+
+export const achievementDefinitions: AchievementDefinition[] = [
+  {
+    id: 'streak_10',
+    title: 'Bookworm',
+    description: 'Maintain a 10 day reading streak',
+    type: 'gold',
+    getProgress: stats => ({ progress: stats.currentStreak, max: 10 }),
+  },
+  {
+    id: 'minutes_300',
+    title: 'Marathon Reader',
+    description: 'Read for 300 minutes',
+    type: 'silver',
+    getProgress: stats => ({ progress: stats.totalMinutesRead, max: 300 }),
+  },
+  {
+    id: 'books_5',
+    title: 'Finisher',
+    description: 'Finish 5 books',
+    type: 'bronze',
+    getProgress: stats => ({ progress: stats.completedBookIds.length, max: 5 }),
+  },
+  {
+    id: 'import_10',
+    title: 'Collector',
+    description: 'Import 10 books',
+    type: 'bronze',
+    getProgress: stats => ({ progress: stats.totalBooksImported, max: 10 }),
+  },
+];
+
+export interface Achievement {
+  id: string;
+  title: string;
+  description: string;
+  type: 'gold' | 'silver' | 'bronze' | 'locked';
+  progress?: number;
+  maxProgress?: number;
+}
+
+export function computeAchievements(stats: import('../types').UserStats): Achievement[] {
+  return achievementDefinitions.map(def => {
+    const { progress, max } = def.getProgress(stats);
+    const unlocked = progress >= max;
+    return {
+      id: def.id,
+      title: def.title,
+      description: def.description,
+      type: unlocked ? def.type : 'locked',
+      ...(unlocked ? {} : { progress, maxProgress: max }),
+    };
+  });
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -15,81 +15,6 @@ import { useStats } from "@/contexts/StatsContext"; // Import useStats
 
 // Removed recentBooks and recommendedBooks
 
-const achievements = [ // Kept achievements as it's not part of this subtask's scope to remove
-  {
-    id: "a1",
-    title: "Bookworm",
-    description: "Read for 10 days in a row",
-    type: "gold" as const,
-    isNew: true,
-  },
-  {
-    id: "a2",
-    title: "Chapter Master",
-    description: "Complete 50 chapters",
-    type: "silver" as const,
-  },
-  {
-    id: "a3",
-    title: "Early Bird",
-    description: "Read before 7 AM for 5 days",
-    type: "bronze" as const,
-  },
-  {
-    id: "a4",
-    title: "Book Collector",
-    description: "Add 20 books to your library",
-    type: "bronze" as const,
-  },
-  {
-    id: "a5",
-    title: "Night Owl",
-    description: "Read after 10 PM for 7 days",
-    type: "locked" as const,
-    progress: 4,
-    maxProgress: 7,
-  },
-  {
-    id: "a6",
-    title: "Marathon Reader",
-    description: "Read for 3 hours straight",
-    type: "locked" as const,
-    progress: 90,
-    maxProgress: 180,
-  },
-  {
-    id: "a7",
-    title: "Critic",
-    description: "Leave reviews for 10 books",
-    type: "locked" as const,
-    progress: 3,
-    maxProgress: 10,
-  },
-  {
-    id: "a8",
-    title: "Genre Explorer",
-    description: "Read books from 5 different genres",
-    type: "locked" as const,
-    progress: 3,
-    maxProgress: 5,
-  },
-  {
-    id: "a9",
-    title: "Audiobook Enthusiast",
-    description: "Listen to 5 audiobooks",
-    type: "locked" as const,
-    progress: 2,
-    maxProgress: 5,
-  },
-  {
-    id: "a10",
-    title: "Social Reader",
-    description: "Share 3 quotes on social media",
-    type: "locked" as const,
-    progress: 0,
-    maxProgress: 3,
-  },
-];
 
 const Index = () => {
   const [books, setBooks] = useState<Book[]>([]);
@@ -320,14 +245,7 @@ const Index = () => {
             </TabsContent>
 
             <TabsContent value="stats" className="mt-2">
-              <ReaderStats
-                booksCompleted={userStats.completedBookIds.length}
-                minutesRead={Math.round(userStats.totalMinutesRead)}
-                minutesListened={Math.round(userStats.totalMinutesListened)}
-                currentStreak={userStats.currentStreak}
-                longestStreak={userStats.longestStreak}
-                achievements={achievements} // Keep passing static achievements
-              />
+              <ReaderStats />
             </TabsContent>
           </Tabs>
         </section>


### PR DESCRIPTION
## Summary
- implement a utility that defines achievements and computes progress
- show achievements dynamically in `ReaderStats` using `StatsContext`
- stop passing static achievement data from `Index`
- add unit tests for achievement computation

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6853bf032c688328a280c4c7b183d185